### PR TITLE
Fix NPE if a decision table has an empty input expression

### DIFF
--- a/dmn-engine/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -200,12 +200,6 @@ class DmnParser(configuration: Configuration,
     val rules = decisionTable.getRules.asScala
     val outputs = decisionTable.getOutputs.asScala
 
-    val defaultOutputValues = outputs
-      .map(
-        o =>
-          Option(o.getDefaultOutputEntry)
-            .map(parseFeelExpression))
-
     val parsedOutputs = outputs.map(o => {
       val value = Option(o.getOutputValues).map(_.getText.getTextContent)
       val defaultValue =

--- a/dmn-engine/src/test/resources/decisiontable/empty-expression.dmn
+++ b/dmn-engine/src/test/resources/decisiontable/empty-expression.dmn
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_16rwaqm" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="discount" name="Discount">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="Customer" camunda:inputVariable="">
+        <inputExpression id="inputExpression1" typeRef="string">
+</inputExpression>
+      </input>
+      <input id="InputClause_0948jsx" label="Order Size" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_0541nfx" typeRef="integer">        <text>orderSize</text>
+</inputExpression>
+      </input>
+      <output id="output1" label="Discount" name="discount" typeRef="double" />
+    </decisionTable>
+  </decision>
+</definitions>

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineTest.scala
@@ -6,14 +6,16 @@ import org.scalatest.matchers.should.Matchers
 
 class DmnEngineTest extends AnyFlatSpec with Matchers {
 
-  val engine = new DmnEngine
+  private val engine = new DmnEngine
 
-  def discountDecision =
+  private def discountDecision =
     getClass.getResourceAsStream("/decisiontable/discount.dmn")
-  def invalidExpressionDecision =
+  private def invalidExpressionDecision =
     getClass.getResourceAsStream("/decisiontable/invalid-expression.dmn")
-  def expressionLanguageDecision =
+  private def expressionLanguageDecision =
     getClass.getResourceAsStream("/decisiontable/expression-language.dmn")
+  private def emptyExpressionDecision =
+    getClass.getResourceAsStream("/decisiontable/empty-expression.dmn")
 
   "A DMN engine" should "evaluate a decision table" in {
 
@@ -84,6 +86,18 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
 
     failure.message should include(
       "Expression language 'groovy' is not supported")
+  }
+
+  it should "report parse failures if an expression has no content" in {
+
+    val parseResult = engine.parse(emptyExpressionDecision)
+
+    parseResult.isLeft should be(true)
+
+    val failure = parseResult.left.get
+
+    failure.message should include(
+      "The expression 'inputExpression1' must not be empty.")
   }
 
 }


### PR DESCRIPTION
Handle empty expressions in the parser.

close #26 