### PR TITLE
Escape names with the correct symbol

### DIFF
--- a/dmn-engine/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -470,7 +470,7 @@ class DmnParser(configuration: Configuration,
     (expression /: namesWithSpaces)(
       (e, name) =>
         e.replaceAll("""([(,.]|\s|^)(""" + name + """)([(),.]|\s|$)""",
-                     "$1'$2'$3"))
+                     "$1`$2`$3"))
   }
 
   private def getNamesToEscape(model: DmnModelInstance): Iterable[String] = {

--- a/dmn-engine/src/test/resources/config/decision_with_dash.dmn
+++ b/dmn-engine/src/test/resources/config/decision_with_dash.dmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/agilepro/dmn-tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+
+	<decision name="GreetingMessage" id="greeting">
+	  <context>
+            <contextEntry>
+                <variable name="First-Name"/>
+                <literalExpression>
+                    <text>name</text>
+                </literalExpression>
+            </contextEntry>
+            <contextEntry>
+                <literalExpression>
+                    <text>"Hello " + First-Name</text>
+                </literalExpression>
+            </contextEntry>
+        </context>
+	</decision>
+
+</definitions>

--- a/dmn-engine/src/test/resources/config/decision_with_spaces.dmn
+++ b/dmn-engine/src/test/resources/config/decision_with_spaces.dmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/agilepro/dmn-tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+
+	<decision name="GreetingMessage" id="greeting">
+	  <context>
+            <contextEntry>
+                <variable name="First Name"/>
+                <literalExpression>
+                    <text>name</text>
+                </literalExpression>
+            </contextEntry>
+            <contextEntry>
+                <literalExpression>
+                    <text>"Hello " + First Name</text>
+                </literalExpression>
+            </contextEntry>
+        </context>
+	</decision>
+
+</definitions>

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
@@ -1,0 +1,33 @@
+package org.camunda.dmn
+
+import org.camunda.dmn.DmnEngine._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DmnEngineConfigurationTest extends AnyFlatSpec with Matchers {
+
+  private val engine = new DmnEngine(
+    configuration = Configuration(
+      escapeNamesWithSpaces = true,
+      escapeNamesWithDashes = true
+    ))
+
+  private def decisionWithSpaces =
+    getClass.getResourceAsStream("/config/decision_with_spaces.dmn")
+
+  private def decisionWithDash =
+    getClass.getResourceAsStream("/config/decision_with_dash.dmn")
+
+  "The DMN engine" should "evaluate a decision with spaces" in {
+
+    engine.eval(decisionWithSpaces, "greeting", Map("name" -> "DMN")) should be(
+      Right(Result("Hello DMN")))
+  }
+
+  it should "evaluate a decision with dash" in {
+
+    engine.eval(decisionWithDash, "greeting", Map("name" -> "DMN")) should be(
+      Right(Result("Hello DMN")))
+  }
+
+}


### PR DESCRIPTION
* escape names with spaces or dashes using the supported symbol of the FEEL engine

closes #63 