### PR TITLE
Evaluation result contains the audit log

### DIFF
--- a/camunda-plugin/src/main/scala/org/camunda/dmn/camunda/plugin/CamundaDmnEngine.scala
+++ b/camunda-plugin/src/main/scala/org/camunda/dmn/camunda/plugin/CamundaDmnEngine.scala
@@ -194,8 +194,8 @@ class CamundaDmnEngine(engine: DmnEngine, onEval: CamundaDmnEngine.EvalListener)
       result: EvalResult,
       evaluatedDecision: DmnDecision): DmnDecisionResult = {
     result match {
-      case NilResult => null
-      case Result(value) =>
+      case NilResult(_) => null
+      case Result(value, _) =>
         value match {
           case list: List[_] if (hasCollectResult(evaluatedDecision)) => {
             val entries = list.map(item =>

--- a/camunda-plugin/src/main/scala/org/camunda/dmn/camunda/plugin/CamundaDmnEnginePlugin.scala
+++ b/camunda-plugin/src/main/scala/org/camunda/dmn/camunda/plugin/CamundaDmnEnginePlugin.scala
@@ -20,9 +20,8 @@ class CamundaDmnEnginePlugin extends AbstractProcessEnginePlugin {
           throw new ProcessEngineException("history listener is not created"))
     })
 
-    val dmnEngine = new CamundaDmnEngine(
-      new DmnEngine(auditLogListeners = List(auditLogListener)),
-      auditLogListener.onEvalDecision)
+    val dmnEngine =
+      new CamundaDmnEngine(new DmnEngine(), auditLogListener.onEvalDecision)
 
     // replace the default Camunda DMN engine
     config.setDmnEngine(dmnEngine)

--- a/dmn-engine/src/test/scala/org/camunda/dmn/BkmTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/BkmTest.scala
@@ -1,6 +1,5 @@
 package org.camunda.dmn
 
-import org.camunda.dmn.DmnEngine._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -15,36 +14,34 @@ class BkmTest extends AnyFlatSpec with Matchers with DecisionTest {
 
   "A BKM with a Literal Expression" should "be invoked as function" in {
     eval(literalExpression, "literalExpression", Map("x" -> 2, "y" -> 3)) should be(
-      Result(5))
+      5)
   }
 
   "A BKM with a Context" should "be invoked as function" in {
     eval(context, "context", Map("x" -> 2, "y" -> 3)) should be(
-      Result(
-        Map(
-          "Sum" -> 5,
-          "Multiply" -> 6
-        )))
+      Map(
+        "Sum" -> 5,
+        "Multiply" -> 6
+      ))
   }
 
   "A BKM with a Relation" should "be invoked as function" in {
     eval(relation, "relation", Map("x" -> 2, "y" -> 3)) should be(
-      Result(
-        List(
-          Map("rate" -> "A", "fee" -> 5),
-          Map("rate" -> "B", "fee" -> 7.5),
-          Map("rate" -> "C", "fee" -> 8.75)
-        )))
+      List(
+        Map("rate" -> "A", "fee" -> 5),
+        Map("rate" -> "B", "fee" -> 7.5),
+        Map("rate" -> "C", "fee" -> 8.75)
+      ))
   }
 
   "A BKM with a Decision Table" should "be invoked as function" in {
     eval(decisionTable, "decisionTable", Map("x" -> "Business", "y" -> 7)) should be(
-      Result(0.1))
+      0.1)
   }
 
   "A BKM without encapsulated logic" should "be ignored" in {
     eval(withoutEncapsulatedLogic, "literalExpression", Map("x" -> 2, "y" -> 3)) should be(
-      Result(5))
+      5)
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/ContextTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/ContextTest.scala
@@ -1,6 +1,5 @@
 package org.camunda.dmn
 
-import org.camunda.dmn.DmnEngine._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -13,27 +12,25 @@ class ContextTest extends AnyFlatSpec with Matchers with DecisionTest {
 
   "A context" should "return static values" in {
     eval(simpleContext, "applicantData", Map()) should be(
-      Result(
-        Map("Age" -> 51,
-            "MaritalStatus" -> "M",
-            "EmploymentStatus" -> "EMPLOYED",
-            "ExistingCustomer" -> false)))
+      Map("Age" -> 51,
+          "MaritalStatus" -> "M",
+          "EmploymentStatus" -> "EMPLOYED",
+          "ExistingCustomer" -> false))
   }
 
   it should "invocate BKM" in {
     eval(contextWithInvocation,
          "discount",
          Map("Customer" -> "Business", "OrderSize" -> 7)) should be(
-      Result(Map("Discount" -> 0.1, "ExistingCustomer" -> false)))
+      Map("Discount" -> 0.1, "ExistingCustomer" -> false))
   }
 
   it should "return nested values" in {
     eval(nestedContext, "applicantData", Map()) should be(
-      Result(
-        Map("EmploymentStatus" -> "EMPLOYED",
-            "Monthly" -> Map("Income" -> 10000.00,
-                             "Repayments" -> 2500.00,
-                             "Expenses" -> 3000.00))))
+      Map("EmploymentStatus" -> "EMPLOYED",
+          "Monthly" -> Map("Income" -> 10000.00,
+                           "Repayments" -> 2500.00,
+                           "Expenses" -> 3000.00)))
   }
 
   "A context with final result" should "return only final value" in {
@@ -42,8 +39,7 @@ class ContextTest extends AnyFlatSpec with Matchers with DecisionTest {
       "Affordability" -> Map("PreBureauRiskCategory" -> "DECLINE",
                              "InstallmentAffordable" -> true))
 
-    eval(eligibilityContext, "eligibility", variables) should be(
-      Result("INELIGIBLE"))
+    eval(eligibilityContext, "eligibility", variables) should be("INELIGIBLE")
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DecisionTableHitPolicyTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DecisionTableHitPolicyTest.scala
@@ -1,6 +1,5 @@
 package org.camunda.dmn
 
-import org.camunda.dmn.DmnEngine._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -33,20 +32,19 @@ class DecisionTableHitPolicyTest
   "The decision table 'Discount' (Unique)" should "return '0.1'" in {
     eval(discountDecision,
          "discount",
-         Map("customer" -> "Business", "orderSize" -> 7)) should be(Result(0.1))
+         Map("customer" -> "Business", "orderSize" -> 7)) should be(0.1)
   }
 
   it should "return '0.15'" in {
     eval(discountDecision,
          "discount",
-         Map("customer" -> "Business", "orderSize" -> 15)) should be(
-      Result(0.15))
+         Map("customer" -> "Business", "orderSize" -> 15)) should be(0.15)
   }
 
   it should "return '0.05'" in {
     eval(discountDecision,
          "discount",
-         Map("customer" -> "Private", "orderSize" -> 9)) should be(Result(0.05))
+         Map("customer" -> "Private", "orderSize" -> 9)) should be(0.05)
   }
 
   "The decision table 'Routing Rules' (Output Order)" should "return all values" in {
@@ -54,7 +52,7 @@ class DecisionTableHitPolicyTest
       Map("age" -> 17, "riskCategory" -> "HIGH", "deptReview" -> true)
 
     eval(routingRulesDecision, "routingRules", context) should be(
-      Result(List(
+      List(
         Map("routing" -> "DECLINE",
             "reviewLevel" -> "NONE",
             "reason" -> "Applicant too young"),
@@ -67,7 +65,7 @@ class DecisionTableHitPolicyTest
         Map("routing" -> "ACCEPT",
             "reviewLevel" -> "NONE",
             "reason" -> "Acceptable")
-      )))
+      ))
   }
 
   it should "return two values" in {
@@ -75,14 +73,14 @@ class DecisionTableHitPolicyTest
       Map("age" -> 25, "riskCategory" -> "MEDIUM", "deptReview" -> true)
 
     eval(routingRulesDecision, "routingRules", context) should be(
-      Result(List(
+      List(
         Map("routing" -> "REFER",
             "reviewLevel" -> "LEVEL 2",
             "reason" -> "Applicant under dept review"),
         Map("routing" -> "ACCEPT",
             "reviewLevel" -> "NONE",
             "reason" -> "Acceptable")
-      )))
+      ))
   }
 
   it should "return single value" in {
@@ -90,39 +88,39 @@ class DecisionTableHitPolicyTest
       Map("age" -> 25, "riskCategory" -> "MEDIUM", "deptReview" -> false)
 
     eval(routingRulesDecision, "routingRules", context) should be(
-      Result(
-        List(Map("routing" -> "ACCEPT",
-                 "reviewLevel" -> "NONE",
-                 "reason" -> "Acceptable"))))
+      List(
+        Map("routing" -> "ACCEPT",
+            "reviewLevel" -> "NONE",
+            "reason" -> "Acceptable")))
   }
 
   "The decision table 'Applicant Risk Rating' (Unique)" should "return 'Medium'" in {
     eval(applicantRiskRatingDecision,
          "applicantRiskRating",
          Map("applicantAge" -> 65, "medicalHistory" -> "good")) should be(
-      Result("Medium"))
+      "Medium")
+
     eval(applicantRiskRatingDecision,
          "applicantRiskRating",
          Map("applicantAge" -> 40, "medicalHistory" -> "bad")) should be(
-      Result("Medium"))
+      "Medium")
+
     eval(applicantRiskRatingDecision,
          "applicantRiskRating",
          Map("applicantAge" -> 22, "medicalHistory" -> "bad")) should be(
-      Result("Medium"))
+      "Medium")
   }
 
   it should "return 'High'" in {
     eval(applicantRiskRatingDecision,
          "applicantRiskRating",
-         Map("applicantAge" -> 65, "medicalHistory" -> "bad")) should be(
-      Result("High"))
+         Map("applicantAge" -> 65, "medicalHistory" -> "bad")) should be("High")
   }
 
   it should "return 'Low'" in {
     eval(applicantRiskRatingDecision,
          "applicantRiskRating",
-         Map("applicantAge" -> 22, "medicalHistory" -> "good")) should be(
-      Result("Low"))
+         Map("applicantAge" -> 22, "medicalHistory" -> "good")) should be("Low")
   }
 
   "The decision table 'Person Loan Compliance' (Any)" should "return 'Not Compliant'" in {
@@ -131,7 +129,7 @@ class DecisionTableHitPolicyTest
                       "loanBalance" -> 50000)
 
     eval(personLoanComplianceDecision, "personLoanCompliance", context) should be(
-      Result("Not Compliant"))
+      "Not Compliant")
   }
 
   it should "return 'Compliant'" in {
@@ -140,36 +138,36 @@ class DecisionTableHitPolicyTest
                       "loanBalance" -> 10000)
 
     eval(personLoanComplianceDecision, "personLoanCompliance", context) should be(
-      Result("Compliant"))
+      "Compliant")
   }
 
   "The decision table 'Applicant Risk Rating' (Priority)" should "return 'High'" in {
     eval(applicantRiskRatingPriorityDecision,
          "applicantRiskRating",
-         Map("applicantAge" -> 65, "medicalHistory" -> "bad")) should be(
-      Result("High"))
+         Map("applicantAge" -> 65, "medicalHistory" -> "bad")) should be("High")
   }
 
   it should "return 'Medium'" in {
     eval(applicantRiskRatingPriorityDecision,
          "applicantRiskRating",
          Map("applicantAge" -> 55, "medicalHistory" -> "bad")) should be(
-      Result("Medium"))
+      "Medium")
+
     eval(applicantRiskRatingPriorityDecision,
          "applicantRiskRating",
          Map("applicantAge" -> 30, "medicalHistory" -> "good")) should be(
-      Result("Medium"))
+      "Medium")
+
     eval(applicantRiskRatingPriorityDecision,
          "applicantRiskRating",
          Map("applicantAge" -> 20, "medicalHistory" -> "bad")) should be(
-      Result("Medium"))
+      "Medium")
   }
 
   it should "return 'Low'" in {
     eval(applicantRiskRatingPriorityDecision,
          "applicantRiskRating",
-         Map("applicantAge" -> 20, "medicalHistory" -> "good")) should be(
-      Result("Low"))
+         Map("applicantAge" -> 20, "medicalHistory" -> "good")) should be("Low")
   }
 
   "The decision table 'Special Discount' (First)" should "return '0'" in {
@@ -177,8 +175,7 @@ class DecisionTableHitPolicyTest
                       "customerLocation" -> "Non-US",
                       "typeOfCustomer" -> "Retailer")
 
-    eval(specialDiscountDecision, "specialDiscount", context) should be(
-      Result(0))
+    eval(specialDiscountDecision, "specialDiscount", context) should be(0)
   }
 
   it should "return '5'" in {
@@ -186,8 +183,7 @@ class DecisionTableHitPolicyTest
                       "customerLocation" -> "US",
                       "typeOfCustomer" -> "Retailer")
 
-    eval(specialDiscountDecision, "specialDiscount", context) should be(
-      Result(5))
+    eval(specialDiscountDecision, "specialDiscount", context) should be(5)
   }
 
   it should "return '10'" in {
@@ -195,120 +191,110 @@ class DecisionTableHitPolicyTest
                       "customerLocation" -> "US",
                       "typeOfCustomer" -> "Wholesaler")
 
-    eval(specialDiscountDecision, "specialDiscount", context) should be(
-      Result(10))
+    eval(specialDiscountDecision, "specialDiscount", context) should be(10)
   }
 
   "The decision table 'Holidays' (Collect-Sum)" should "return '30'" in {
     eval(holidaysCollectSumDecision,
          "holidays",
-         Map("age" -> 58, "yearsOfService" -> 31)) should be(Result(30))
+         Map("age" -> 58, "yearsOfService" -> 31)) should be(30)
   }
 
   it should "return '22'" in {
     eval(holidaysCollectSumDecision,
          "holidays",
-         Map("age" -> 25, "yearsOfService" -> 2)) should be(Result(22))
+         Map("age" -> 25, "yearsOfService" -> 2)) should be(22)
   }
 
   it should "return '27'" in {
     eval(holidaysCollectSumDecision,
          "holidays",
-         Map("age" -> 16, "yearsOfService" -> 1)) should be(Result(27))
+         Map("age" -> 16, "yearsOfService" -> 1)) should be(27)
   }
 
   it should "return '24'" in {
     eval(holidaysCollectSumDecision,
          "holidays",
-         Map("age" -> 46, "yearsOfService" -> 19)) should be(Result(24))
+         Map("age" -> 46, "yearsOfService" -> 19)) should be(24)
   }
 
   "The decision table 'Discount' (Collect-Max)" should "return '0.1'" in {
     eval(discountCollectMaxDecision,
          "discount",
-         Map("customer" -> "Business", "orderSize" -> 8)) should be(Result(0.1))
+         Map("customer" -> "Business", "orderSize" -> 8)) should be(0.1)
   }
 
   it should "return '0.15'" in {
     eval(discountCollectMaxDecision,
          "discount",
-         Map("customer" -> "Business", "orderSize" -> 12)) should be(
-      Result(0.15))
+         Map("customer" -> "Business", "orderSize" -> 12)) should be(0.15)
   }
 
   it should "return '0.06'" in {
     eval(discountCollectMaxDecision,
          "discount",
-         Map("customer" -> "Private", "orderSize" -> 17)) should be(
-      Result(0.06))
+         Map("customer" -> "Private", "orderSize" -> 17)) should be(0.06)
   }
 
   it should "return '0.05'" in {
     eval(discountCollectMaxDecision,
          "discount",
-         Map("customer" -> "Private", "orderSize" -> 13)) should be(
-      Result(0.05))
+         Map("customer" -> "Private", "orderSize" -> 13)) should be(0.05)
   }
 
   "The decision table 'Insurance Fee' (Collect-Min)" should "return '200'" in {
-    eval(insuranceFeeDecision, "insuranceFee", Map("years" -> 1)) should be(
-      Result(200))
+    eval(insuranceFeeDecision, "insuranceFee", Map("years" -> 1)) should be(200)
   }
 
   it should "return '190'" in {
-    eval(insuranceFeeDecision, "insuranceFee", Map("years" -> 4)) should be(
-      Result(190))
+    eval(insuranceFeeDecision, "insuranceFee", Map("years" -> 4)) should be(190)
   }
 
   it should "return '100'" in {
     eval(insuranceFeeDecision, "insuranceFee", Map("years" -> 16)) should be(
-      Result(100))
+      100)
   }
 
   "The decision table 'Holidays' (Collect)" should "return '22,3,5'" in {
     eval(holidaysCollectDecision,
          "holidays",
-         Map("age" -> 58, "yearsOfService" -> 31)) should be(
-      Result(List(22, 3, 5)))
+         Map("age" -> 58, "yearsOfService" -> 31)) should be(List(22, 3, 5))
   }
 
   it should "return '22'" in {
     eval(holidaysCollectDecision,
          "holidays",
-         Map("age" -> 25, "yearsOfService" -> 2)) should be(Result(List(22)))
+         Map("age" -> 25, "yearsOfService" -> 2)) should be(List(22))
   }
 
   "The decision table 'Holidays' (Output Order)" should "return '22,5,3'" in {
     eval(holidaysOutputOrderDecision,
          "holidays",
-         Map("age" -> 58, "yearsOfService" -> 31)) should be(
-      Result(List(22, 5, 3)))
+         Map("age" -> 58, "yearsOfService" -> 31)) should be(List(22, 5, 3))
   }
 
   it should "return '22'" in {
     eval(holidaysOutputOrderDecision,
          "holidays",
-         Map("age" -> 25, "yearsOfService" -> 2)) should be(Result(List(22)))
+         Map("age" -> 25, "yearsOfService" -> 2)) should be(List(22))
   }
 
   it should "return '22,5'" in {
     eval(holidaysOutputOrderDecision,
          "holidays",
-         Map("age" -> 16, "yearsOfService" -> 1)) should be(Result(List(22, 5)))
+         Map("age" -> 16, "yearsOfService" -> 1)) should be(List(22, 5))
   }
 
   it should "return '22,2,2'" in {
     eval(holidaysOutputOrderDecision,
          "holidays",
-         Map("age" -> 46, "yearsOfService" -> 19)) should be(
-      Result(List(22, 2, 2)))
+         Map("age" -> 46, "yearsOfService" -> 19)) should be(List(22, 2, 2))
   }
 
   it should "return '22,2'" in {
     eval(holidaysOutputOrderDecision,
          "holidays",
-         Map("age" -> 40, "yearsOfService" -> 19)) should be(
-      Result(List(22, 2)))
+         Map("age" -> 40, "yearsOfService" -> 19)) should be(List(22, 2))
   }
 
   "The decision table 'Student Financial Package Eligibility' (Rule Order)" should "return '20% Scholarship, 30% Loan'" in {
@@ -316,7 +302,7 @@ class DecisionTableHitPolicyTest
       Map("gpa" -> 3.6, "acitvitiesCount" -> 4, "socialMembership" -> "Yes")
 
     eval(eligibilityDecision, "eligibility", context) should be(
-      Result(List("20% Scholarship", "30% Loan")))
+      List("20% Scholarship", "30% Loan"))
   }
 
   it should "return '20% Work-On-Campus'" in {
@@ -324,7 +310,7 @@ class DecisionTableHitPolicyTest
       Map("gpa" -> 3.6, "acitvitiesCount" -> 4, "socialMembership" -> "No")
 
     eval(eligibilityDecision, "eligibility", context) should be(
-      Result(List("20% Work-On-Campus")))
+      List("20% Work-On-Campus"))
   }
 
   it should "return '5% Work-On-Campus'" in {
@@ -332,7 +318,7 @@ class DecisionTableHitPolicyTest
       Map("gpa" -> 3.0, "acitvitiesCount" -> 4, "socialMembership" -> "Yes")
 
     eval(eligibilityDecision, "eligibility", context) should be(
-      Result(List("5% Work-On-Campus")))
+      List("5% Work-On-Campus"))
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DecisionTableTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DecisionTableTest.scala
@@ -1,6 +1,5 @@
 package org.camunda.dmn
 
-import org.camunda.dmn.DmnEngine._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -20,33 +19,31 @@ class DecisionTableTest extends AnyFlatSpec with Matchers with DecisionTest {
   "A decision table with single output" should "return single value" in {
     eval(discountDecision,
          "discount",
-         Map("customer" -> "Business", "orderSize" -> 7)) should be(Result(0.1))
+         Map("customer" -> "Business", "orderSize" -> 7)) should be(0.1)
   }
 
   it should "return value list" in {
     eval(holidaysDecision, "holidays", Map("age" -> 58, "yearsOfService" -> 31)) should be(
-      Result(List(22, 5, 3)))
+      List(22, 5, 3))
   }
 
   it should "return null if no rule match" in {
     eval(discountDecision,
          "discount",
-         Map("customer" -> "Something else", "orderSize" -> 9)) should be(
-      NilResult)
+         Map("customer" -> "Something else", "orderSize" -> 9)) should be(None)
   }
 
   it should "return the default-output if no rule match" in {
     eval(discountWithDefaultOutputDecision,
          "discount",
-         Map("customer" -> "Something else", "orderSize" -> 9)) should be(
-      Result(0.05))
+         Map("customer" -> "Something else", "orderSize" -> 9)) should be(0.05)
   }
 
   "A decision table with multiple outputs" should "return single values" in {
     val context = Map("customer" -> "Business", "orderSize" -> 7)
 
     eval(adjustmentsDecision, "adjustments", context) should be(
-      Result(Map("discount" -> 0.1, "shipping" -> "Air")))
+      Map("discount" -> 0.1, "shipping" -> "Air"))
   }
 
   it should "return value list" in {
@@ -54,27 +51,27 @@ class DecisionTableTest extends AnyFlatSpec with Matchers with DecisionTest {
       Map("age" -> 25, "riskCategory" -> "MEDIUM", "deptReview" -> true)
 
     eval(routingRulesDecision, "routingRules", context) should be(
-      Result(List(
+      List(
         Map("routing" -> "REFER",
             "reviewLevel" -> "LEVEL 2",
             "reason" -> "Applicant under dept review"),
         Map("routing" -> "ACCEPT",
             "reviewLevel" -> "NONE",
             "reason" -> "Acceptable")
-      )))
+      ))
   }
 
   it should "return null if no rule match" in {
     val context = Map("customer" -> "Something else", "orderSize" -> 9)
 
-    eval(adjustmentsDecision, "adjustments", context) should be(NilResult)
+    eval(adjustmentsDecision, "adjustments", context) should be(None)
   }
 
   it should "return the default-output if no rule match" in {
     val context = Map("customer" -> "Something else", "orderSize" -> 9)
 
     eval(adjustmentsWithDefaultOutputDecision, "adjustments", context) should be(
-      Result(Map("discount" -> 0.05, "shipping" -> "Ground")))
+      Map("discount" -> 0.05, "shipping" -> "Ground"))
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DecisionTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DecisionTest.scala
@@ -5,6 +5,8 @@ import org.camunda.dmn.parser.ParsedDmn
 import org.camunda.dmn.Audit.AuditLog
 import org.camunda.dmn.Audit.AuditLogListener
 
+import java.io.InputStream
+
 trait DecisionTest {
 
   val engine = new DmnEngine(auditLogListeners = List(new TestAuditLogListener))
@@ -13,14 +15,14 @@ trait DecisionTest {
     val stream = getClass.getResourceAsStream(file)
     engine.parse(stream) match {
       case Right(dmn)    => dmn
-      case Left(failure) => throw new IllegalArgumentException(failure.message)
+      case Left(failure) => throw new AssertionError(failure.message)
     }
   }
 
   def eval(decision: ParsedDmn, id: String, context: Map[String, Any]): Any =
     engine.eval(decision, id, context) match {
-      case Right(result) => result
-      case Left(failure) => failure
+      case Right(result)                 => result.value
+      case Left(EvalFailure(failure, _)) => failure
     }
 
   var lastAuditLog: AuditLog = _

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
@@ -1,6 +1,7 @@
 package org.camunda.dmn
 
 import org.camunda.dmn.DmnEngine._
+import org.camunda.dmn.parser.ParsedDmn
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -12,22 +13,35 @@ class DmnEngineConfigurationTest extends AnyFlatSpec with Matchers {
       escapeNamesWithDashes = true
     ))
 
-  private def decisionWithSpaces =
-    getClass.getResourceAsStream("/config/decision_with_spaces.dmn")
+  private def decisionWithSpaces = "/config/decision_with_spaces.dmn"
 
-  private def decisionWithDash =
-    getClass.getResourceAsStream("/config/decision_with_dash.dmn")
+  private def decisionWithDash = "/config/decision_with_dash.dmn"
+
+  private def parse(resourceName: String): ParsedDmn = {
+    val resource = getClass.getResourceAsStream(resourceName)
+    engine.parse(resource) match {
+      case Right(parsedDmn) => parsedDmn
+      case Left(failure)    => throw new AssertionError(failure)
+    }
+  }
 
   "The DMN engine" should "evaluate a decision with spaces" in {
 
-    engine.eval(decisionWithSpaces, "greeting", Map("name" -> "DMN")) should be(
-      Right(Result("Hello DMN")))
+    val parsedDmn = parse(decisionWithSpaces)
+    val result =
+      engine.eval(parsedDmn, "greeting", Map("name" -> "DMN"))
+
+    result.isRight should be(true)
+    result.map(_.value should be("Hello DMN"))
   }
 
   it should "evaluate a decision with dash" in {
 
-    engine.eval(decisionWithDash, "greeting", Map("name" -> "DMN")) should be(
-      Right(Result("Hello DMN")))
+    val parsedDmn = parse(decisionWithDash)
+    val result = engine.eval(parsedDmn, "greeting", Map("name" -> "DMN"))
+
+    result.isRight should be(true)
+    result.map(_.value should be("Hello DMN"))
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineTest.scala
@@ -1,8 +1,11 @@
 package org.camunda.dmn
 
 import org.camunda.dmn.DmnEngine._
+import org.camunda.dmn.parser.ParsedDmn
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import java.io.InputStream
 
 class DmnEngineTest extends AnyFlatSpec with Matchers {
 
@@ -17,26 +20,37 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
   private def emptyExpressionDecision =
     getClass.getResourceAsStream("/decisiontable/empty-expression.dmn")
 
+  private def parse(resource: InputStream): ParsedDmn = {
+    engine.parse(resource) match {
+      case Right(decision) => decision
+      case Left(failure)   => throw new AssertionError(failure)
+    }
+  }
+
   "A DMN engine" should "evaluate a decision table" in {
 
-    engine.eval(discountDecision,
-                "discount",
-                Map("customer" -> "Business", "orderSize" -> 7)) should be(
-      Right(Result(0.1)))
+    val parsedDmn = parse(discountDecision)
+    val result = engine.eval(parsedDmn,
+                             "discount",
+                             Map("customer" -> "Business", "orderSize" -> 7))
+
+    result.isRight should be(true)
+    result.map(_.value should be(0.1))
   }
 
   it should "parse and evaluate a decision table" in {
 
     val parseResult = engine.parse(discountDecision)
-
     parseResult.isRight should be(true)
 
-    val parsedDmn = parseResult.right.get
+    parseResult.map { parsedDmn =>
+      val result = engine.eval(parsedDmn,
+                               "discount",
+                               Map("customer" -> "Business", "orderSize" -> 7))
 
-    engine.eval(parsedDmn,
-                "discount",
-                Map("customer" -> "Business", "orderSize" -> 7)) should be(
-      Right(Result(0.1)))
+      result.isRight should be(true)
+      result.map(_.value should be(0.1))
+    }
   }
 
   it should "report parse failures" in {
@@ -44,10 +58,8 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
     val parseResult = engine.parse(invalidExpressionDecision)
 
     parseResult.isLeft should be(true)
-
-    val failure = parseResult.left.get
-
-    failure.message should include("Failed to parse FEEL unary-tests '> 10L'")
+    parseResult.left.map(
+      _.message should include("Failed to parse FEEL unary-tests '> 10L'"))
   }
 
   it should "report parse failures on evaluation" in {
@@ -56,24 +68,21 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
       engine.eval(invalidExpressionDecision, "discount", Map[String, Any]())
 
     result.isLeft should be(true)
-
-    val failure = result.left.get
-
-    failure.message should include("Failed to parse FEEL unary-tests '> 10L'")
+    result.left.map(
+      _.message should include("Failed to parse FEEL unary-tests '> 10L'"))
   }
 
   it should "report an evaluation failure" in {
 
+    val parsedDmn = parse(discountDecision)
     val result = engine.eval(
-      discountDecision,
+      parsedDmn,
       "discount",
       Map[String, Any]("customer" -> "Business", "orderSize" -> "foo"))
 
     result.isLeft should be(true)
-
-    val failure = result.left.get
-
-    failure.message should include("failed to evaluate expression '< 10'")
+    result.left.map(
+      _.failure.message should include("failed to evaluate expression '< 10'"))
   }
 
   it should "report parse failures if expression language is set" in {
@@ -81,11 +90,8 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
     val parseResult = engine.parse(expressionLanguageDecision)
 
     parseResult.isLeft should be(true)
-
-    val failure = parseResult.left.get
-
-    failure.message should include(
-      "Expression language 'groovy' is not supported")
+    parseResult.left.map(
+      _.message should include("Expression language 'groovy' is not supported"))
   }
 
   it should "report parse failures if an expression has no content" in {
@@ -98,6 +104,41 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
 
     failure.message should include(
       "The expression 'inputExpression1' must not be empty.")
+  }
+
+  it should "evaluate a decision and return the audit log" in {
+    val parsedDmn = parse(discountDecision)
+    val result = engine.eval(parsedDmn,
+                             "discount",
+                             Map("customer" -> "Business", "orderSize" -> 7))
+
+    result.isRight should be(true)
+    result.map {
+      case Result(value, auditLog) =>
+        value should be(0.1)
+
+        auditLog.dmn should be(parsedDmn)
+        auditLog.rootEntry.id should be("discount")
+        auditLog.rootEntry.name should be("Discount")
+    }
+  }
+
+  it should "report an evaluation failure and return the audit log" in {
+    val parsedDmn = parse(discountDecision)
+    val result =
+      engine.eval(parsedDmn,
+                  "discount",
+                  Map("customer" -> "Business", "orderSize" -> "foo"))
+
+    result.isLeft should be(true)
+    result.left.map {
+      case EvalFailure(failure, auditLog) =>
+        failure.message should include("failed to evaluate expression '< 10'")
+
+        auditLog.dmn should be(parsedDmn)
+        auditLog.rootEntry.id should be("discount")
+        auditLog.rootEntry.name should be("Discount")
+    }
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DmnVersionCompatibilityTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DmnVersionCompatibilityTest.scala
@@ -4,35 +4,30 @@ import org.camunda.dmn.DmnEngine._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class DmnVersionCompatibilityTest extends AnyFlatSpec with Matchers {
+class DmnVersionCompatibilityTest
+    extends AnyFlatSpec
+    with Matchers
+    with DecisionTest {
 
-  private val engine = new DmnEngine
+  private def dmn1_1_decision = parse("/dmn1.1/greeting.dmn")
 
-  private def dmn1_1_decision =
-    getClass.getResourceAsStream("/dmn1.1/greeting.dmn")
+  private def dmn1_2_decision = parse("/dmn1.2/greeting.dmn")
 
-  private def dmn1_2_decision =
-    getClass.getResourceAsStream("/dmn1.2/greeting.dmn")
-
-  private def dmn1_3_decision =
-    getClass.getResourceAsStream("/dmn1.2/greeting.dmn")
+  private def dmn1_3_decision = parse("/dmn1.2/greeting.dmn")
 
   "The DMN engine" should "evaluate a DMN 1.1 decision" in {
-
-    engine.eval(dmn1_1_decision, "greeting", Map("name" -> "DMN")) should be(
-      Right(Result("Hello DMN")))
+    eval(dmn1_1_decision, "greeting", Map("name" -> "DMN")) should be(
+      "Hello DMN")
   }
 
   it should "evaluate a DMN 1.2 decision" in {
-
-    engine.eval(dmn1_2_decision, "greeting", Map("name" -> "DMN")) should be(
-      Right(Result("Hello DMN")))
+    eval(dmn1_2_decision, "greeting", Map("name" -> "DMN")) should be(
+      "Hello DMN")
   }
 
   it should "evaluate a DMN 1.3 decision" in {
-
-    engine.eval(dmn1_3_decision, "greeting", Map("name" -> "DMN")) should be(
-      Right(Result("Hello DMN")))
+    eval(dmn1_3_decision, "greeting", Map("name" -> "DMN")) should be(
+      "Hello DMN")
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/FunctionDefinitionTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/FunctionDefinitionTest.scala
@@ -23,15 +23,15 @@ class FunctionDefinitionTest
     val expected = (amount * rate / 12) / (1 - (1 + rate / 12)
       .pow(-36)) // ~ 3975.982590125562
 
-    eval(applicantData, "applicantData", Map()) should be(Result(expected))
+    eval(applicantData, "applicantData", Map()) should be(expected)
   }
 
   "A FEEL user function" should "be invoked inside a context" in {
-    eval(userFunction, "userFunction", Map()) should be(Result(5))
+    eval(userFunction, "userFunction", Map()) should be(5)
   }
 
   it should "be invoked outside of the context" in {
-    eval(contextWithFunction, "calculation", Map()) should be(Result(5))
+    eval(contextWithFunction, "calculation", Map()) should be(5)
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/InvocationTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/InvocationTest.scala
@@ -15,35 +15,35 @@ class InvocationTest extends AnyFlatSpec with Matchers with DecisionTest {
   "An invocation" should "execute a BKM with parameters" in {
     eval(discountDecision,
          "discount",
-         Map("Customer" -> "Business", "OrderSize" -> 7)) should be(Result(0.1))
+         Map("Customer" -> "Business", "OrderSize" -> 7)) should be(0.1)
   }
 
   it should "execute a BKM without parameters" in {
     eval(withoutParameters, "applicantData", Map()) should be(
-      Result(
-        Map("Age" -> 51,
-            "MaritalStatus" -> "M",
-            "EmploymentStatus" -> "EMPLOYED",
-            "ExistingCustomer" -> false)))
+      Map("Age" -> 51,
+          "MaritalStatus" -> "M",
+          "EmploymentStatus" -> "EMPLOYED",
+          "ExistingCustomer" -> false))
   }
 
   it should "fail if parameter is not set" in {
-    engine.eval(missingParameter, "discount", Map("OrderSize" -> 7)) should be(
-      Left(Failure("no parameter found with name 'customer'")))
+    eval(missingParameter, "discount", Map("OrderSize" -> 7)) should be(
+      Failure("no parameter found with name 'customer'"))
   }
 
   it should "fail if parameter has the wrong type" in {
-    engine.eval(discountDecision,
-                "discount",
-                Map("Customer" -> "Business", "OrderSize" -> "foo")) should be(
-      Left(Failure("expected 'number' but found 'ValString(foo)'")))
+    eval(discountDecision,
+         "discount",
+         Map("Customer" -> "Business", "OrderSize" -> "foo")) should be(
+      Failure("expected 'number' but found 'ValString(foo)'"))
   }
 
   it should "fail if knowledge requirement is missing" in {
-    engine.eval(missingKnowledgeRequirementDecision,
-                "discount",
-                Map("Customer" -> "Business", "OrderSize" -> 7)) should be(
-      Left(Failure("no BKM found with name 'Discount table'")))
+    val result = engine.parse(missingKnowledgeRequirementDecision)
+
+    result.isLeft should be(true)
+    result.left.map(
+      _.message should be("no BKM found with name 'Discount table'"))
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/ListTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/ListTest.scala
@@ -10,7 +10,7 @@ class ListTest extends AnyFlatSpec with Matchers with DecisionTest {
 
   "A list with literal expressions" should "return result as list" in {
     eval(applicantData, "applicantData", Map()) should be(
-      Result(Map("MonthlyOutgoings" -> List(2500, 3000))))
+      Map("MonthlyOutgoings" -> List(2500, 3000)))
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/LiteralExpressionTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/LiteralExpressionTest.scala
@@ -13,13 +13,12 @@ class LiteralExpressionTest
   lazy val typeMismatch = parse("/literalexpression/type-mismatch.dmn")
 
   "A literal expression" should "be evaluated as decision" in {
-    eval(greeting, "greeting", Map("name" -> "John")) should be(
-      Result("Hello John"))
+    eval(greeting, "greeting", Map("name" -> "John")) should be("Hello John")
   }
 
   it should "fail when result doesn't match type" in {
-    engine.eval(typeMismatch, "greeting", Map("name" -> "Frank")) should be(
-      Left(Failure("expected 'number' but found 'ValString(Hello Frank)'")))
+    eval(typeMismatch, "greeting", Map("name" -> "Frank")) should be(
+      Failure("expected 'number' but found 'ValString(Hello Frank)'"))
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/RelationTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/RelationTest.scala
@@ -12,7 +12,7 @@ class RelationTest extends AnyFlatSpec with Matchers with DecisionTest {
 
   "A relation" should "return a list of contexts" in {
     eval(applicantData, "applicantData", Map()) should be(
-      Result(Map("CreditHistory" -> List(
+      Map("CreditHistory" -> List(
         Map(
           "recordDate" -> LocalDate.parse("2008-03-12"),
           "event" -> "home mortgage",
@@ -23,7 +23,7 @@ class RelationTest extends AnyFlatSpec with Matchers with DecisionTest {
           "event" -> "foreclosure warning",
           "weight" -> 150
         )
-      ))))
+      )))
   }
 
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/RequiredDecisionTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/RequiredDecisionTest.scala
@@ -12,10 +12,10 @@ class RequiredDecisionTest extends AnyFlatSpec with Matchers with DecisionTest {
   "A decision" should "evaluate a required decision" in {
     eval(discountDecision,
          "price",
-         Map("customer" -> "Business", "orderSize" -> 7)) should be(Result(10))
+         Map("customer" -> "Business", "orderSize" -> 7)) should be(10)
   }
 
   it should "evaluate multiple required decision" in {
-    eval(applicantDataDecision, "income", Map()) should be(Result(10000.00))
+    eval(applicantDataDecision, "income", Map()) should be(10000.00)
   }
 }

--- a/dmn-engine/src/test/scala/org/camunda/dmn/spi/DmnEngineSpiTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/spi/DmnEngineSpiTest.scala
@@ -1,6 +1,7 @@
-package org.camunda.dmn
+package org.camunda.dmn.spi
 
-import org.camunda.dmn.DmnEngine._
+import org.camunda.dmn.DmnEngine
+import org.camunda.dmn.parser.ParsedDmn
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -8,24 +9,36 @@ class DmnEngineSpiTest extends AnyFlatSpec with Matchers {
 
   val engine = new DmnEngine
 
-  def decision = getClass.getResourceAsStream("/spi/SpiTests.dmn")
+  lazy val decision: ParsedDmn = {
+    val resource = getClass.getResourceAsStream("/spi/SpiTests.dmn")
+    engine.parse(resource) match {
+      case Right(decision) => decision
+      case Left(failure)   => throw new AssertionError(failure)
+    }
+  }
 
   "A custom value mapper" should "transform the input" in {
 
-    engine.eval(decision, "varInput", Map("in" -> "bar")) should be(
-      Right(Result("baz")))
+    val result = engine.eval(decision, "varInput", Map("in" -> "bar"))
+
+    result.isRight should be(true)
+    result.map(_.value should be("baz"))
   }
 
   it should "transform the output" in {
 
-    engine.eval(decision, "varOutput", Map[String, Any]()) should be(
-      Right(Result("baz")))
+    val result = engine.eval(decision, "varOutput", Map[String, Any]())
+
+    result.isRight should be(true)
+    result.map(_.value should be("baz"))
   }
 
   "A custom function provider" should "provide a function" in {
 
-    engine.eval(decision, "invFunction", Map("x" -> 2)) should be(
-      Right(Result(3)))
+    val result = engine.eval(decision, "invFunction", Map("x" -> 2))
+
+    result.isRight should be(true)
+    result.map(_.value should be(3))
   }
 
 }

--- a/engine-rest/src/main/scala/org/camunda/dmn/rest/DmnEngineRestServlet.scala
+++ b/engine-rest/src/main/scala/org/camunda/dmn/rest/DmnEngineRestServlet.scala
@@ -44,9 +44,9 @@ class DmnEngineRestServlet(engine: StandaloneEngine)
     val variables = parsedBody.extract[Map[String, Any]]
 
     engine.evalDecisionById(id, variables) match {
-      case Left(failure)    => BadRequest(failure)
-      case Right(NilResult) => DecisionEvalResult(null)
-      case Right(Result(r)) => DecisionEvalResult(r)
+      case Left(failure)            => BadRequest(failure)
+      case Right(NilResult(_))      => DecisionEvalResult(null)
+      case Right(Result(result, _)) => DecisionEvalResult(result)
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
       <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.2</version>
         <configuration>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>

--- a/standalone-engine/src/main/scala/org/camunda/dmn/standalone/StandaloneEngine.scala
+++ b/standalone-engine/src/main/scala/org/camunda/dmn/standalone/StandaloneEngine.scala
@@ -24,7 +24,10 @@ class StandaloneEngine(engine: DmnEngine, repository: DecisionRepository) {
       variables: Map[String, Any]): Either[Failure, EvalResult] = {
     repository
       .getDecisionById(id)
-      .map(d => engine.eval(d.parsedDmn, id, variables))
+      .map(d =>
+        engine.eval(d.parsedDmn, id, variables).left.map {
+          case EvalFailure(failure, _) => failure
+      })
       .getOrElse(Left(Failure(s"No decision found with id '$id'")))
   }
 
@@ -33,7 +36,10 @@ class StandaloneEngine(engine: DmnEngine, repository: DecisionRepository) {
       variables: Map[String, Any]): Either[Failure, EvalResult] = {
     repository
       .getDecisionByName(name)
-      .map(d => engine.evalByName(d.parsedDmn, name, variables))
+      .map(d =>
+        engine.evalByName(d.parsedDmn, name, variables).left.map {
+          case EvalFailure(failure, _) => failure
+      })
       .getOrElse(Left(Failure(s"No decision found with name '$name'")))
   }
 

--- a/standalone-engine/src/test/scala/org/camunda/dmn/standalone/StandaloneEngineTest.scala
+++ b/standalone-engine/src/test/scala/org/camunda/dmn/standalone/StandaloneEngineTest.scala
@@ -40,19 +40,23 @@ class StandaloneEngineTest
   it should "evaluate decision by id" in {
     val engine = StandaloneEngine.fileSystemRepository(repository)
 
-    engine.evalDecisionById(
-      "discount",
-      Map("customer" -> "Business", "orderSize" -> 7)) should be(
-      Right(Result(0.1)))
+    val result =
+      engine.evalDecisionById("discount",
+                              Map("customer" -> "Business", "orderSize" -> 7))
+
+    result.isRight should be(true)
+    result.map(_.value should be(0.1))
   }
 
   it should "evaluate decision by name" in {
     val engine = StandaloneEngine.fileSystemRepository(repository)
 
-    engine.evalDecisionByName(
-      "Discount",
-      Map("customer" -> "Business", "orderSize" -> 7)) should be(
-      Right(Result(0.1)))
+    val result =
+      engine.evalDecisionByName("Discount",
+                                Map("customer" -> "Business", "orderSize" -> 7))
+
+    result.isRight should be(true)
+    result.map(_.value should be(0.1))
   }
 
   it should "return empty list if repository is empty" in {

--- a/zeebe-worker/src/main/scala/org/camunda/dmn/zeebe/DmnJobHandler.scala
+++ b/zeebe-worker/src/main/scala/org/camunda/dmn/zeebe/DmnJobHandler.scala
@@ -21,8 +21,8 @@ class DmnJobHandler(engine: StandaloneEngine) extends JobHandler {
         engine.evalDecisionById(decisionId, variables) match {
           case Left(Failure(msg)) =>
             error(s"Fail to evaluate decision '$decisionId': $msg")
-          case Right(NilResult) => complete(client, job, null)
-          case Right(Result(r)) => complete(client, job, r)
+          case Right(NilResult(_))      => complete(client, job, null)
+          case Right(Result(result, _)) => complete(client, job, result)
         }
       }
     }


### PR DESCRIPTION
## Description

* change the engine API to include the audit log as part of the decision result
* the result type change from `Either[Failure, EvalResult]` to `Either[EvalFailure, EvalResult]` (= type alias `DecisionResult`)
* extend `EvalResult` by new properties `value` and `auditLog`
* change constructor of `Result` from `Result(value: Any)` to `Result(value: Any, auditLog: AuditLog)`
* change constructor of `NilResult` from `NilResult()` to `NilResult(auditLog: AuditLog)`
* change left side of the result from `Failure` to `EvalFailure(failure: Failure, auditLog: AuditLog)` 

## Related issues

closes #82
