### PR TITLE
Lazy decision evaluation

### DIFF
--- a/dmn-engine/src/main/scala/org/camunda/dmn/DmnEngine.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/DmnEngine.scala
@@ -123,8 +123,8 @@ class DmnEngine(configuration: DmnEngine.Configuration =
 
   val parser = new DmnParser(
     configuration = configuration,
-    parser = feelEngine.parseExpression(_).left.map(_.message),
-    unaryTestsParser = feelEngine.parseUnaryTests(_).left.map(_.message)
+    feelParser = feelEngine.parseExpression(_).left.map(_.message),
+    feelUnaryTestsParser = feelEngine.parseUnaryTests(_).left.map(_.message)
   )
 
   val decisionEval = new DecisionEvaluator(eval = this.evalExpression,

--- a/dmn-engine/src/main/scala/org/camunda/dmn/DmnEngine.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/DmnEngine.scala
@@ -64,12 +64,14 @@ object DmnEngine {
   }
 
   case class Configuration(escapeNamesWithSpaces: Boolean = false,
-                           escapeNamesWithDashes: Boolean = false)
+                           escapeNamesWithDashes: Boolean = false,
+                           lazyEvaluation: Boolean = false)
 
   class Builder {
 
     private var escapeNamesWithSpaces_ = false
     private var escapeNamesWithDashes_ = false
+    private var lazyEvaluation_ = false
     private var auditLogListeners_ = List[AuditLogListener]().toBuffer
 
     def escapeNamesWithSpaces(enabled: Boolean): Builder = {
@@ -82,6 +84,11 @@ object DmnEngine {
       this
     }
 
+    def lazyEvaluation(enabled: Boolean): Builder = {
+      lazyEvaluation_ = enabled
+      this
+    }
+
     def addAuditListener(listener: AuditLogListener): Builder = {
       auditLogListeners_ += listener
       this
@@ -89,10 +96,10 @@ object DmnEngine {
 
     def build: DmnEngine =
       new DmnEngine(
-        configuration = DmnEngine.Configuration(escapeNamesWithSpaces =
-                                                  escapeNamesWithSpaces_,
-                                                escapeNamesWithDashes =
-                                                  escapeNamesWithDashes_),
+        configuration = DmnEngine.Configuration(
+          escapeNamesWithSpaces = escapeNamesWithSpaces_,
+          escapeNamesWithDashes = escapeNamesWithDashes_,
+          lazyEvaluation = lazyEvaluation_),
         auditLogListeners = auditLogListeners_.toList
       )
 

--- a/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/DecisionTableEvaluator.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/DecisionTableEvaluator.scala
@@ -3,10 +3,30 @@ package org.camunda.dmn.evaluation
 import org.camunda.dmn.DmnEngine._
 import org.camunda.dmn.FunctionalHelper._
 import org.camunda.feel._
-import org.camunda.feel.syntaxtree.{Val, ValBoolean, ValContext, ValError, ValList, ValNull, ValNumber, ValString}
+import org.camunda.feel.syntaxtree.{
+  Val,
+  ValBoolean,
+  ValContext,
+  ValError,
+  ValList,
+  ValNull,
+  ValNumber,
+  ValString
+}
 import org.camunda.bpm.model.dmn._
-import org.camunda.dmn.parser.{ParsedDecisionTable, ParsedExpression, ParsedInput, ParsedOutput, ParsedRule}
-import org.camunda.dmn.Audit.{DecisionTableEvaluationResult, EvaluatedInput, EvaluatedOutput, EvaluatedRule}
+import org.camunda.dmn.parser.{
+  ParsedDecisionTable,
+  ParsedExpression,
+  ParsedInput,
+  ParsedOutput,
+  ParsedRule
+}
+import org.camunda.dmn.Audit.{
+  DecisionTableEvaluationResult,
+  EvaluatedInput,
+  EvaluatedOutput,
+  EvaluatedRule
+}
 import org.camunda.feel.context.Context.StaticContext
 
 class DecisionTableEvaluator(

--- a/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/DecisionTableEvaluator.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/DecisionTableEvaluator.scala
@@ -3,30 +3,10 @@ package org.camunda.dmn.evaluation
 import org.camunda.dmn.DmnEngine._
 import org.camunda.dmn.FunctionalHelper._
 import org.camunda.feel._
-import org.camunda.feel.syntaxtree.{
-  ParsedExpression,
-  Val,
-  ValBoolean,
-  ValContext,
-  ValError,
-  ValList,
-  ValNull,
-  ValNumber,
-  ValString
-}
+import org.camunda.feel.syntaxtree.{Val, ValBoolean, ValContext, ValError, ValList, ValNull, ValNumber, ValString}
 import org.camunda.bpm.model.dmn._
-import org.camunda.dmn.parser.{
-  ParsedDecisionTable,
-  ParsedInput,
-  ParsedOutput,
-  ParsedRule
-}
-import org.camunda.dmn.Audit.{
-  DecisionTableEvaluationResult,
-  EvaluatedInput,
-  EvaluatedOutput,
-  EvaluatedRule
-}
+import org.camunda.dmn.parser.{ParsedDecisionTable, ParsedExpression, ParsedInput, ParsedOutput, ParsedRule}
+import org.camunda.dmn.Audit.{DecisionTableEvaluationResult, EvaluatedInput, EvaluatedOutput, EvaluatedRule}
 import org.camunda.feel.context.Context.StaticContext
 
 class DecisionTableEvaluator(

--- a/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/FunctionDefinitionEvaluator.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/FunctionDefinitionEvaluator.scala
@@ -2,13 +2,8 @@ package org.camunda.dmn.evaluation
 
 import org.camunda.dmn.DmnEngine._
 import org.camunda.dmn.FunctionalHelper._
-import org.camunda.dmn.parser.ParsedFunctionDefinition
-import org.camunda.feel.syntaxtree.{
-  ParsedExpression,
-  Val,
-  ValError,
-  ValFunction
-}
+import org.camunda.dmn.parser.{ParsedExpression, ParsedFunctionDefinition}
+import org.camunda.feel.syntaxtree.{Val, ValError, ValFunction}
 
 class FunctionDefinitionEvaluator(
     eval: (ParsedExpression, EvalContext) => Either[Failure, Val]) {

--- a/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/InvocationEvaluator.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/InvocationEvaluator.scala
@@ -2,8 +2,8 @@ package org.camunda.dmn.evaluation
 
 import org.camunda.dmn.DmnEngine._
 import org.camunda.dmn.FunctionalHelper._
-import org.camunda.dmn.parser.{ParsedBusinessKnowledgeModel, ParsedInvocation}
-import org.camunda.feel.syntaxtree.{ParsedExpression, Val}
+import org.camunda.dmn.parser.{ParsedBusinessKnowledgeModel, ParsedExpression, ParsedInvocation}
+import org.camunda.feel.syntaxtree.Val
 
 class InvocationEvaluator(
     eval: (ParsedExpression, EvalContext) => Either[Failure, Val],

--- a/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/InvocationEvaluator.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/InvocationEvaluator.scala
@@ -2,7 +2,11 @@ package org.camunda.dmn.evaluation
 
 import org.camunda.dmn.DmnEngine._
 import org.camunda.dmn.FunctionalHelper._
-import org.camunda.dmn.parser.{ParsedBusinessKnowledgeModel, ParsedExpression, ParsedInvocation}
+import org.camunda.dmn.parser.{
+  ParsedBusinessKnowledgeModel,
+  ParsedExpression,
+  ParsedInvocation
+}
 import org.camunda.feel.syntaxtree.Val
 
 class InvocationEvaluator(

--- a/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/LiteralExpressionEvaluator.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/LiteralExpressionEvaluator.scala
@@ -1,16 +1,11 @@
 package org.camunda.dmn.evaluation
 
 import org.camunda.dmn.DmnEngine._
-import org.camunda.feel._
-import org.camunda.feel.syntaxtree.{Val, ValBoolean, ValError, ValFunction}
-import org.camunda.bpm.model.dmn.instance.{LiteralExpression, UnaryTests}
-
-import scala.Left
-import scala.Right
-import org.camunda.dmn.parser.{EmptyExpression, ExpressionFailure, FeelExpression, ParsedExpression, ParsedLiteralExpression}
-import org.camunda.dmn.Audit.SingleEvaluationResult
+import org.camunda.dmn.parser._
 import org.camunda.feel
+import org.camunda.feel._
 import org.camunda.feel.context.Context.StaticContext
+import org.camunda.feel.syntaxtree.{Val, ValBoolean, ValFunction}
 
 class LiteralExpressionEvaluator(feelEngine: FeelEngine) {
 
@@ -22,17 +17,19 @@ class LiteralExpressionEvaluator(feelEngine: FeelEngine) {
     result
   }
 
-  def evalExpression(expression: ParsedExpression, context: EvalContext):Either[Failure, Val] = {
+  def evalExpression(expression: ParsedExpression,
+                     context: EvalContext): Either[Failure, Val] = {
     expression match {
-      case exp: FeelExpression => evalFeelExpression(exp.expression, context)
-      case EmptyExpression => Right(ValBoolean(true))
+      case FeelExpression(exp)        => evalFeelExpression(exp, context)
+      case EmptyExpression            => Right(ValBoolean(true))
       case ExpressionFailure(failure) => Left(Failure(message = failure))
-      case other => Left(Failure(s"Failed to evaluate expression '$other'"))
+      case other =>
+        Left(Failure(message = s"Failed to evaluate expression '$other'"))
     }
   }
 
   private def evalFeelExpression(expression: feel.syntaxtree.ParsedExpression,
-                         context: EvalContext): Either[Failure, Val] = {
+                                 context: EvalContext): Either[Failure, Val] = {
     val functions = context.variables
       .filter { case (k, v) => v.isInstanceOf[ValFunction] }
       .map { case (k, f) => k -> List(f.asInstanceOf[ValFunction]) }

--- a/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/LiteralExpressionEvaluator.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/evaluation/LiteralExpressionEvaluator.scala
@@ -2,31 +2,37 @@ package org.camunda.dmn.evaluation
 
 import org.camunda.dmn.DmnEngine._
 import org.camunda.feel._
-import org.camunda.feel.syntaxtree.{
-  ParsedExpression,
-  Val,
-  ValError,
-  ValFunction
-}
+import org.camunda.feel.syntaxtree.{Val, ValBoolean, ValError, ValFunction}
 import org.camunda.bpm.model.dmn.instance.{LiteralExpression, UnaryTests}
 
 import scala.Left
 import scala.Right
-import org.camunda.dmn.parser.ParsedLiteralExpression
+import org.camunda.dmn.parser.{EmptyExpression, ExpressionFailure, FeelExpression, ParsedExpression, ParsedLiteralExpression}
 import org.camunda.dmn.Audit.SingleEvaluationResult
+import org.camunda.feel
 import org.camunda.feel.context.Context.StaticContext
 
 class LiteralExpressionEvaluator(feelEngine: FeelEngine) {
 
   def evalExpression(literalExpression: ParsedLiteralExpression,
                      context: EvalContext): Either[Failure, Val] = {
+
     val result = evalExpression(literalExpression.expression, context)
     context.audit(literalExpression, result)
     result
   }
 
-  def evalExpression(expression: ParsedExpression,
-                     context: EvalContext): Either[Failure, Val] = {
+  def evalExpression(expression: ParsedExpression, context: EvalContext):Either[Failure, Val] = {
+    expression match {
+      case exp: FeelExpression => evalFeelExpression(exp.expression, context)
+      case EmptyExpression => Right(ValBoolean(true))
+      case ExpressionFailure(failure) => Left(Failure(message = failure))
+      case other => Left(Failure(s"Failed to evaluate expression '$other'"))
+    }
+  }
+
+  private def evalFeelExpression(expression: feel.syntaxtree.ParsedExpression,
+                         context: EvalContext): Either[Failure, Val] = {
     val functions = context.variables
       .filter { case (k, v) => v.isInstanceOf[ValFunction] }
       .map { case (k, f) => k -> List(f.asInstanceOf[ValFunction]) }

--- a/dmn-engine/src/main/scala/org/camunda/dmn/parser/ParsedDmn.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/parser/ParsedDmn.scala
@@ -2,11 +2,9 @@ package org.camunda.dmn.parser
 
 import org.camunda.bpm.model.dmn.DmnModelInstance
 
-import scala.collection.JavaConverters._
-import org.camunda.bpm.model.dmn.instance.Decision
 import org.camunda.bpm.model.dmn.HitPolicy
 import org.camunda.bpm.model.dmn.BuiltinAggregator
-import org.camunda.feel.syntaxtree.ParsedExpression
+import org.camunda.feel
 
 case class ParsedDmn(model: DmnModelInstance,
                      decisions: Iterable[ParsedDecision]) {
@@ -16,6 +14,18 @@ case class ParsedDmn(model: DmnModelInstance,
   val decisionsByName: Map[String, ParsedDecision] =
     decisions.map(d => d.name -> d).toMap
 }
+
+// ---------------
+
+sealed trait ParsedExpression
+
+case class ExpressionFailure(failure: String) extends ParsedExpression
+
+case class FeelExpression(expression: feel.syntaxtree.ParsedExpression) extends ParsedExpression
+
+case object EmptyExpression extends ParsedExpression
+
+// ---------------
 
 sealed trait ParsedDecisionLogicContainer {
   val id: String

--- a/dmn-engine/src/main/scala/org/camunda/dmn/parser/ParsedDmn.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/parser/ParsedDmn.scala
@@ -21,7 +21,8 @@ sealed trait ParsedExpression
 
 case class ExpressionFailure(failure: String) extends ParsedExpression
 
-case class FeelExpression(expression: feel.syntaxtree.ParsedExpression) extends ParsedExpression
+case class FeelExpression(expression: feel.syntaxtree.ParsedExpression)
+    extends ParsedExpression
 
 case object EmptyExpression extends ParsedExpression
 

--- a/dmn-engine/src/test/resources/config/decision_with_invalid_expression.dmn
+++ b/dmn-engine/src/test/resources/config/decision_with_invalid_expression.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/agilepro/dmn-tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+
+	<decision name="GreetingMessage" id="greeting">
+	  <literalExpression>
+        <text>"Hello " + name !</text>
+    </literalExpression>
+	</decision>
+
+</definitions>

--- a/dmn-engine/src/test/resources/config/with_invalid_bkm.dmn
+++ b/dmn-engine/src/test/resources/config/with_invalid_bkm.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/agilepro/dmn-tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+
+	<decision name="GreetingMessage" id="greeting">
+	  <knowledgeRequirement>
+      <requiredKnowledge href="#invalidBkm"/>
+    </knowledgeRequirement>
+	  <literalExpression>
+        <text>"Hello " + name</text>
+    </literalExpression>
+	</decision>
+
+  <businessKnowledgeModel id="invalidBkm" name="InvalidBKM">
+      <encapsulatedLogic>
+        <literalExpression>
+              <text>"invalid" !</text>
+          </literalExpression>
+      </encapsulatedLogic>
+      <variable name="InvalidBKM" />
+    </businessKnowledgeModel>
+
+</definitions>

--- a/dmn-engine/src/test/resources/config/with_invalid_decision.dmn
+++ b/dmn-engine/src/test/resources/config/with_invalid_decision.dmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/agilepro/dmn-tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+
+	<decision name="GreetingMessage" id="greeting">
+	  <literalExpression>
+        <text>"Hello " + name</text>
+    </literalExpression>
+	</decision>
+
+	<decision name="InvalidDecision" id="invalid">
+  	  <literalExpression>
+          <text>"invalid" !</text>
+      </literalExpression>
+  	</decision>
+
+</definitions>

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineTest.scala
@@ -59,7 +59,7 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
 
     parseResult.isLeft should be(true)
     parseResult.left.map(
-      _.message should include("Failed to parse FEEL unary-tests '> 10L'"))
+      _.message should include("FEEL unary-tests: failed to parse expression"))
   }
 
   it should "report parse failures on evaluation" in {
@@ -69,7 +69,7 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
 
     result.isLeft should be(true)
     result.left.map(
-      _.message should include("Failed to parse FEEL unary-tests '> 10L'"))
+      _.message should include("FEEL unary-tests: failed to parse expression"))
   }
 
   it should "report an evaluation failure" in {


### PR DESCRIPTION
## Description

* add a new configuration option for lazy evaluation (default: `false`)
* if the option is enabled then it ignores failures on parsing
* instead, it writes log statements to make the failures visible (log level: `warning`)
* if an invalid expression is evaluated then it reports the failure

## Related issues

closes #81 
