### PR TITLE
Escape names from parameter in BKM

### DIFF
--- a/dmn-engine/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -1,19 +1,22 @@
 package org.camunda.dmn.parser
 
 import java.io.InputStream
-
 import org.camunda.dmn.logger
 import org.camunda.bpm.model.dmn._
 import org.camunda.bpm.model.dmn.impl.DmnModelConstants
 import org.camunda.bpm.model.dmn.instance.{
   BusinessKnowledgeModel,
+  Column,
   Context,
   Decision,
   DecisionTable,
   Expression,
+  FormalParameter,
   FunctionDefinition,
+  InformationItem,
   Invocation,
   LiteralExpression,
+  Parameter,
   Relation,
   UnaryTests,
   Variable,
@@ -488,8 +491,11 @@ class DmnParser(
 
   private def getNamesToEscape(model: DmnModelInstance): Iterable[String] = {
 
-    val variables = model.getModelElementsByType(classOf[Variable])
-    val variableNames = variables.asScala.map(_.getName)
+    val names = model
+      .getModelElementsByType(classOf[InformationItem])
+      .asScala
+      .filterNot(classOf[Column].isInstance(_))
+      .map(_.getName)
 
     val nameFilter: (String => Boolean) = {
       if (configuration.escapeNamesWithSpaces && configuration.escapeNamesWithDashes) {
@@ -504,7 +510,7 @@ class DmnParser(
       }
     }
 
-    val namesToEscape = variableNames.filter(nameFilter)
+    val namesToEscape = names.filter(nameFilter)
     namesToEscape.toList.distinct
       .sortBy(_.length)
       .reverse

--- a/dmn-engine/src/test/resources/config/bkm_with_spaces_and_dash.dmn
+++ b/dmn-engine/src/test/resources/config/bkm_with_spaces_and_dash.dmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/agilepro/dmn-tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+
+	<decision name="GreetingMessage" id="greeting">
+	  <knowledgeRequirement>
+      <requiredKnowledge href="#greetingName"/>
+    </knowledgeRequirement>
+	  <literalExpression>
+        <text>"Hello " + greetingName(First Name, Last-Name)</text>
+    </literalExpression>
+	</decision>
+
+  <businessKnowledgeModel id="greetingName" name="greetingName">
+      <encapsulatedLogic>
+        <formalParameter name="First Name" />
+        <formalParameter name="Last-Name" />
+        <literalExpression>
+              <text>First Name + " " + Last-Name</text>
+          </literalExpression>
+      </encapsulatedLogic>
+      <variable name="greetingName" />
+    </businessKnowledgeModel>
+
+</definitions>

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
@@ -26,6 +26,8 @@ class DmnEngineConfigurationTest extends AnyFlatSpec with Matchers {
     getClass.getResourceAsStream("/config/decision_with_spaces.dmn")
   private def decisionWithDash =
     getClass.getResourceAsStream("/config/decision_with_dash.dmn")
+  private def bkmWithSpacesAndDash =
+    getClass.getResourceAsStream("/config/bkm_with_spaces_and_dash.dmn")
   private def decisionWithInvalidExpression =
     getClass.getResourceAsStream("/config/decision_with_invalid_expression.dmn")
   private def decisionWithOtherInvalidDecision =
@@ -51,6 +53,19 @@ class DmnEngineConfigurationTest extends AnyFlatSpec with Matchers {
 
     result.isRight should be(true)
     result.map(_.value should be("Hello DMN"))
+  }
+
+  it should "invoke a BKM with spaces & dash in parameter" in {
+    val result = engineWithEscapeNames
+      .parse(bkmWithSpacesAndDash)
+      .flatMap(
+        engineWithEscapeNames.eval(_,
+                                   "greeting",
+                                   Map("First Name" -> "Luke",
+                                       "Last-Name" -> "Skywalker")))
+
+    result.isRight should be(true)
+    result.map(_.value should be("Hello Luke Skywalker"))
   }
 
   "A DMN engine with lazy evaluation" should "ignore invalid expression on parsing" in {


### PR DESCRIPTION
## Description

* escape parameter and formal parameter names when invoking a BKM if it is enabled in the configs

## Related issues

closes #72 
