### PR TITLE
Add clock to DMN Engine Builder

### DIFF
--- a/dmn-engine/src/test/resources/config/with_specific_date_time.dmn
+++ b/dmn-engine/src/test/resources/config/with_specific_date_time.dmn
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/agilepro/dmn-tck"
+	xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+	xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+
+	<decision name="Current Time" id="currentTime">
+	  <context>
+            <contextEntry>
+                <literalExpression>
+                    <text>now()</text>
+                </literalExpression>
+            </contextEntry>
+        </context>
+	</decision>
+
+</definitions>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds an option to the DMN Engine Builder to pass in a custom FeelEngineClock.

A test case is added to uses the `now()` function to test that the provided custom clock is used by the engine.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #105
