### PR TITLE
Fail early on empty output name for decision table

### DIFF
--- a/dmn-engine/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/dmn-engine/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -211,6 +211,15 @@ class DmnParser(
         "hit policy 'COLLECT' with aggregator is not defined for compound output")
     }
 
+    if (decisionTable.getOutputs.size > 1) {
+      decisionTable.getOutputs
+        .stream()
+        .filter(output => output.getName == null)
+        .forEach(output =>
+          ctx.failures += Failure(
+            s"no output name defined for `${output.getLabel}`"))
+    }
+
     val inputExpressions = decisionTable.getInputs.asScala
       .map(
         i =>

--- a/dmn-engine/src/test/resources/decisiontable/adjustments_empty_output_name.dmn
+++ b/dmn-engine/src/test/resources/decisiontable/adjustments_empty_output_name.dmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_16rwaqm" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
+  <decision id="adjustments" name="Adjustments">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="Customer" camunda:inputVariable="">
+        <inputExpression id="inputExpression1" typeRef="string">
+          <text>customer</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_0948jsx" label="Order Size" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_0541nfx" typeRef="integer">
+          <text>orderSize</text>
+        </inputExpression>
+      </input>
+      <output id="output1" label="Discount" typeRef="double" />
+      <output id="OutputClause_0k33qvs" label="Shipping" name="shipping" typeRef="string" />
+      <rule id="row-958866071-1">
+        <inputEntry id="UnaryTests_1j7evgw">
+          <text>"Business"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1jf21ih">
+          <text>&lt; 10</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_104sjjb">
+          <text>0.1</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1vq9vb3">
+          <text>"Air"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-958866071-2">
+        <description></description>
+        <inputEntry id="UnaryTests_1nz4a49">
+          <text>"Business"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_13nukij">
+          <text>&gt;= 10</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_15ipzxo">
+          <text>0.15</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_116pr0a">
+          <text>"Air"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-958866071-3">
+        <inputEntry id="UnaryTests_1d94e9a">
+          <text>"Private"</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_05iyfwy">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1dx9evc">
+          <text>0.05</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0a0cijs">
+          <text>"Air"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/dmn-engine/src/test/scala/org/camunda/dmn/DecisionTableTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/DecisionTableTest.scala
@@ -12,6 +12,9 @@ class DecisionTableTest extends AnyFlatSpec with Matchers with DecisionTest {
   lazy val adjustmentsDecision = parse("/decisiontable/adjustments.dmn")
   lazy val adjustmentsWithDefaultOutputDecision = parse(
     "/decisiontable/adjustments_default-output.dmn")
+  lazy val adjustmentsWithEmptyOutputNameDecision =
+    getClass.getResourceAsStream(
+      "/decisiontable/adjustments_empty_output_name.dmn")
 
   lazy val routingRulesDecision = parse("/decisiontable/routingRules.dmn")
   lazy val holidaysDecision = parse("/decisiontable/holidays_output_order.dmn")
@@ -74,4 +77,11 @@ class DecisionTableTest extends AnyFlatSpec with Matchers with DecisionTest {
       Map("discount" -> 0.05, "shipping" -> "Ground"))
   }
 
+  it should "fail if an output name is empty" in {
+    val result = engine.parse(adjustmentsWithEmptyOutputNameDecision)
+
+    result.isLeft should be(true)
+    result.left.map(
+      _.message should be("no output name defined for `Discount`"))
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

* A decision table containing multiple outs will result in a NPE when one of these outputs does not define a name. In the parser we can verify that for all outputs a name is defined, or return a failure if it's not.

## Related issues

<!-- 
  Which issues are closed by this PR or are related.
  If you have no issue then create one. This helps to track it and get the confirmation that the behavior is not expected. 
-->

closes #142 
