### PR TITLE
deps: dump feel-engine from 1.13.2 to 1.15.2

### DIFF
--- a/dmn-engine/src/test/resources/spi/SpiTests.dmn
+++ b/dmn-engine/src/test/resources/spi/SpiTests.dmn
@@ -2,7 +2,7 @@
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_16rwaqm" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
   <decision id="varInput" name="Transform Input">
    	<literalExpression>
-        <text>in</text>
+        <text>input</text>
     </literalExpression>
   </decision>
   <decision id="varOutput" name="Transform Output">

--- a/dmn-engine/src/test/scala/org/camunda/dmn/spi/DmnEngineSpiTest.scala
+++ b/dmn-engine/src/test/scala/org/camunda/dmn/spi/DmnEngineSpiTest.scala
@@ -19,7 +19,7 @@ class DmnEngineSpiTest extends AnyFlatSpec with Matchers {
 
   "A custom value mapper" should "transform the input" in {
 
-    val result = engine.eval(decision, "varInput", Map("in" -> "bar"))
+    val result = engine.eval(decision, "varInput", Map("input" -> "bar"))
 
     result.isRight should be(true)
     result.map(_.value should be("baz"))

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <name>DMN Scala Root</name>
 
   <properties>
-    <feel.version>1.13.3</feel.version>
-    <camunda.version>7.16.0</camunda.version>
+    <feel.version>1.15.2</feel.version>
+    <camunda.version>7.18.0</camunda.version>
     <zeebe.version>0.26.5</zeebe.version>
     <version.java>11</version.java>
     <scala.version>2.13.9</scala.version>


### PR DESCRIPTION
## Description

* dump `feel-engine` from `1.13.2` to `1.15.2`
* dump `camunda` from `7.16.0` to `7.18.0`
* adjust test case because of a reserved word

## Related issues

