### PR TITLE
chore: add temporary verify-vault-secrets workflow

### DIFF
--- a/.github/workflows/verify-vault-secrets.yml
+++ b/.github/workflows/verify-vault-secrets.yml
@@ -1,0 +1,35 @@
+---
+# Temporary diagnostic workflow added to validate AppRole / VAULT_SECRET_ID health
+# after the post-wave-2 (May 2026) Vault secret rotation. Authenticates to Vault
+# using the repo-provisioned community AppRole credentials (VAULT_ROLE_ID /
+# VAULT_SECRET_ID) via vault-action v4.0.0 — the exact version pulled in by
+# `camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main`.
+#
+# A successful run proves the community-role SecretID stored in this repo is valid.
+# A 403 / permission denied confirms the SecretID drifted from Vault.
+#
+# Remove this workflow once Vault SecretID health is verified.
+name: Verify Vault Secrets
+
+on:
+  push:
+    branches:
+      - fix/verify-vault-secrets
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Authenticate to Vault and read a community-policy secret
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPOCI_WEBHOOK_URL ;


### PR DESCRIPTION
Diagnostic workflow to validate community-role AppRole (VAULT_ROLE_ID / VAULT_SECRET_ID) health after the post-wave-2 (May 27 2026) Vault SecretID drift. Triggered via workflow_dispatch; will be removed once verified. Do not merge.