### PR TITLE
fix: Accept DMN 1.5 FEEL namespace

### DIFF
--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -36,7 +36,7 @@ object DmnParser {
     DmnModelConstants.FEEL12_NS,
     DmnModelConstants.FEEL13_NS,
     DmnModelConstants.FEEL14_NS,
-    DmnModelConstants.DMN15_NS
+    DmnModelConstants.FEEL15_NS
   ).map(_.toLowerCase())
 }
 

--- a/src/test/scala/org/camunda/dmn/DmnVersionCompatibilityTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnVersionCompatibilityTest.scala
@@ -55,7 +55,7 @@ class DmnVersionCompatibilityTest
   }
 
   it should "evaluate a DMN 1.5 decision" in {
-    eval(dmn1_4_decision, "greeting", Map("name" -> "DMN")) should be(
+    eval(dmn1_5_decision, "greeting", Map("name" -> "DMN")) should be(
       "Hello DMN")
   }
 


### PR DESCRIPTION
## Description

The engine parses a DMN with the FEEL namespace `https://www.omg.org/spec/DMN/20230324/FEEL/`.

## Related issues

closes https://github.com/camunda/dmn-scala/issues/355
